### PR TITLE
Keep code algin with tar@3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+*.swp
+*.swo
+dict

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git@github.com:morungos/WNdb-with-exceptions.git"
   },
   "dependencies": {
-    "tar": "latest"
+    "tar": "3.0.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},

--- a/unpack.js
+++ b/unpack.js
@@ -49,7 +49,7 @@ function extractTarball() {
   input
     .on("error", log)
     .pipe(zlib.Unzip())
-    .pipe(tar.Extract({ path: __dirname }))
+    .pipe(tar.x({ C: __dirname }))
     .on("end", function() {
       copyFiles(files);
     });


### PR DESCRIPTION
As WNdb-with-exceptions references latest version of tar, it breaks some other packages. With this pr, try to fix the error.